### PR TITLE
Fix AnimatedGradientFill README Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,15 @@ struct ContentView: View {
 
             Image(systemName: "figure.walk.circle")
                 .font(.system(size: 300))
-                .colorEffect(
-                    ShaderLibrary.animatedGradientFill(
-                        .float(elapsedTime)
+                .visualEffect { content, proxy in
+                    content
+                        .colorEffect(
+                            ShaderLibrary.animatedGradientFill(
+                                .float2(proxy.size),
+                                .float(elapsedTime)
+                        )
                     )
-                )
+                }
         }
     }
 }


### PR DESCRIPTION
This PR fixes a small issue in the AnimatedGradientFill README example where a `.float2()` size parameter was missing from the Shader input.