### PR TITLE
Some fixes in the readme file sample codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,7 +1282,7 @@ struct ContentView: View {
                     .padding()
                     .background(.blue)
                     .drawingGroup()
-                    .transition(.wind)
+                    .transition(.wind())
             } else {
                 Image(systemName: "figure.run.circle")
                     .font(.system(size: 300))
@@ -1290,7 +1290,7 @@ struct ContentView: View {
                     .padding()
                     .background(.indigo)
                     .drawingGroup()
-                    .transition(.wind)
+                    .transition(.wind())
             }
 
             Button("Toggle Views") {

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Image(systemName: "figure.walk.circle")
     .font(.system(size: 300))
     .colorEffect(
         ShaderLibrary.checkerboard(
-            .color(.red)
+            .color(.red),
             .float(50)
         )
     )
@@ -358,7 +358,7 @@ struct ContentView: View {
 
 ### Gradient Fill
 
-A `colorEffect()` shader that generates generates a gradient fill
+A `colorEffect()` shader that generates a gradient fill
 
 **Parameters:**
 
@@ -367,13 +367,11 @@ A `colorEffect()` shader that generates generates a gradient fill
 Example code:
 
 ```swift
-VStack {
-    Image(systemName: "figure.walk.circle")
-        .font(.system(size: 300))
-        .colorEffect(
-            ShaderLibrary.gradientFill()
-        )
-}
+Image(systemName: "figure.walk.circle")
+    .font(.system(size: 300))
+    .colorEffect(
+        ShaderLibrary.gradientFill()
+    )
 ```
 
 


### PR DESCRIPTION
Modified some sample codes:
- fixed `checkboard` transformation (missing a ",")
- removed a useless "VStack" for `gradientFill`
- added missing "()" for `wind` transition