### PR TITLE
Premultiply alpha more consistently

### DIFF
--- a/Shaders/Generation/Sinebow.metal
+++ b/Shaders/Generation/Sinebow.metal
@@ -78,5 +78,5 @@ using namespace metal;
 
     // Send back the finished color, taking into account the
     // current alpha value.
-    return half4(waveColor, color.a) * color.a;
+    return half4(waveColor, 1.0h) * color.a;
 }

--- a/Shaders/Transformation/AnimatedGradientFill.metal
+++ b/Shaders/Transformation/AnimatedGradientFill.metal
@@ -35,5 +35,5 @@ using namespace metal;
     // Send back variations on the sine of that angle, so we
     // get a range of colors. The use of abs() here avoids
     // negative values for any color component.
-    return half4(abs(sin(angle)), abs(sin(angle + 2.0h)), abs(sin(angle + 4.0h)), color.a) * color.a;
+    return half4(abs(sin(angle)), abs(sin(angle + 2.0h)), abs(sin(angle + 4.0h)), 1.0h) * color.a;
 }

--- a/Shaders/Transformation/GradientFill.metal
+++ b/Shaders/Transformation/GradientFill.metal
@@ -20,5 +20,5 @@ using namespace metal;
 [[ stitchable ]] half4 gradientFill(float2 position, half4 color) {
     // Send back a new color based on the position of the pixel
     // factoring in the original alpha to get smooth edges.
-    return half4(position.x / position.y, 0.0h, position.y / position.x, color.a) * color.a;
+    return half4(position.x / position.y, 0.0h, position.y / position.x, 1.0h) * color.a;
 }

--- a/Shaders/Transformation/Infrared.metal
+++ b/Shaders/Transformation/Infrared.metal
@@ -53,7 +53,7 @@ using namespace metal;
 
         // Create the final color, multiplying by this
         // pixel's alpha (to avoid a hard edge).
-        return half4(newColor, color.a) * color.a;
+        return half4(newColor, 1.0h) * color.a;
     } else {
         // Use the current (transparent) color.
         return color;

--- a/Shaders/Transformation/InvertAlpha.metal
+++ b/Shaders/Transformation/InvertAlpha.metal
@@ -22,5 +22,5 @@ using namespace metal;
 [[ stitchable ]] half4 invertAlpha(float2 position, half4 color, half4 replacement) {
     // Send back the RGB values from our input pixel, but
     // flip the alpha value around.
-    return half4(replacement.rgb, 1.0h - color.a) * (1.0h - color.a);
+    return half4(replacement.rgb, 1.0h) * (1.0h - color.a);
 }


### PR DESCRIPTION
I noticed some of the shaders produced a fringe on antialiased edges because they were, I think unintentionally, multiplying the alpha value by itself. I believe I fixed this by starting with an alpha of `1.0h` in all the places where a color is multiplied by the alpha value. The affected shaders were `AnimatedGradientFill`, `GradientFill`, `Infrared`, `InvertAlpha`, and `Sinebow`.

For example, the animated gradient fill without my fix (there’s a whitish fringe around the edges, especially visible on the left and right sides of the circle and the figure’s right arm):
<img width="1092" alt="Screenshot 2023-11-17 at 4 47 09 PM" src="https://github.com/twostraws/Inferno/assets/3615519/a85c19ab-263d-4251-aa52-9bd5939e430d">

With my fix, the edges are smooth because the alpha of the returned color matches that of the original pixel:
<img width="1092" alt="Screenshot 2023-11-17 at 4 46 43 PM" src="https://github.com/twostraws/Inferno/assets/3615519/99060643-67d7-4d87-9403-36bb9c014a38">
