### PR TITLE
Add variable blur shader from daprice/Variablur

### DIFF
--- a/Sandbox/Inferno.xcodeproj/project.pbxproj
+++ b/Sandbox/Inferno.xcodeproj/project.pbxproj
@@ -61,6 +61,13 @@
 		51DB1BD62AF3FCEC00518737 /* SimpleTransformationShader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DB1BD52AF3FCEC00518737 /* SimpleTransformationShader.swift */; };
 		51DB1BD82AF3FD5500518737 /* TimeTransformationShader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DB1BD72AF3FD5500518737 /* TimeTransformationShader.swift */; };
 		51ED43172B08E1D700EE73E8 /* PlatformShims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51ED43162B08E1D700EE73E8 /* PlatformShims.swift */; };
+		E931DA2A2B1686F8005E940A /* VariableGaussianBlur.metal in Sources */ = {isa = PBXBuildFile; fileRef = E931DA292B1686F8005E940A /* VariableGaussianBlur.metal */; };
+		E931DA2D2B169C7E005E940A /* VisualEffect+variableBlur.swift in Sources */ = {isa = PBXBuildFile; fileRef = E931DA2C2B169C7E005E940A /* VisualEffect+variableBlur.swift */; };
+		E931DA2F2B169CC4005E940A /* View+variableBlur.swift in Sources */ = {isa = PBXBuildFile; fileRef = E931DA2E2B169CC4005E940A /* View+variableBlur.swift */; };
+		E931DA312B169DD2005E940A /* BlurEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = E931DA302B169DD2005E940A /* BlurEffect.swift */; };
+		E931DA332B16A356005E940A /* BlurPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E931DA322B16A356005E940A /* BlurPreview.swift */; };
+		E931DA352B16A68A005E940A /* ProgressiveBlurPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E931DA342B16A68A005E940A /* ProgressiveBlurPreview.swift */; };
+		E931DA372B16A6FE005E940A /* ShapeBlurPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E931DA362B16A6FE005E940A /* ShapeBlurPreview.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -112,7 +119,7 @@
 		51C72BA82AFD36A80094D932 /* LightGrid.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = LightGrid.metal; sourceTree = "<group>"; };
 		51DB1B9F2AF3EFEE00518737 /* Inferno.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Inferno.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		51DB1BA22AF3EFEE00518737 /* InfernoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfernoApp.swift; sourceTree = "<group>"; };
-		51DB1BA42AF3EFEE00518737 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		51DB1BA42AF3EFEE00518737 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; usesTabs = 0; };
 		51DB1BA62AF3EFEF00518737 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		51DB1BA92AF3EFEF00518737 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		51DB1BAB2AF3EFEF00518737 /* Inferno.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Inferno.entitlements; sourceTree = "<group>"; };
@@ -120,6 +127,13 @@
 		51DB1BD52AF3FCEC00518737 /* SimpleTransformationShader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTransformationShader.swift; sourceTree = "<group>"; };
 		51DB1BD72AF3FD5500518737 /* TimeTransformationShader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeTransformationShader.swift; sourceTree = "<group>"; };
 		51ED43162B08E1D700EE73E8 /* PlatformShims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformShims.swift; sourceTree = "<group>"; };
+		E931DA292B1686F8005E940A /* VariableGaussianBlur.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = VariableGaussianBlur.metal; sourceTree = "<group>"; usesTabs = 0; };
+		E931DA2C2B169C7E005E940A /* VisualEffect+variableBlur.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisualEffect+variableBlur.swift"; sourceTree = "<group>"; usesTabs = 0; };
+		E931DA2E2B169CC4005E940A /* View+variableBlur.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+variableBlur.swift"; sourceTree = "<group>"; };
+		E931DA302B169DD2005E940A /* BlurEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurEffect.swift; sourceTree = "<group>"; usesTabs = 0; };
+		E931DA322B16A356005E940A /* BlurPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurPreview.swift; sourceTree = "<group>"; usesTabs = 0; };
+		E931DA342B16A68A005E940A /* ProgressiveBlurPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressiveBlurPreview.swift; sourceTree = "<group>"; usesTabs = 0; };
+		E931DA362B16A6FE005E940A /* ShapeBlurPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeBlurPreview.swift; sourceTree = "<group>"; usesTabs = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +155,7 @@
 				51DB1BD52AF3FCEC00518737 /* SimpleTransformationShader.swift */,
 				51DB1BD72AF3FD5500518737 /* TimeTransformationShader.swift */,
 				516617992AFA519500978554 /* TouchTransformationShader.swift */,
+				E931DA302B169DD2005E940A /* BlurEffect.swift */,
 			);
 			path = ShaderDescriptions;
 			sourceTree = "<group>";
@@ -155,6 +170,9 @@
 				51DB1BD32AF3F8E300518737 /* TimeTransformationPreview.swift */,
 				516617972AFA517C00978554 /* TouchTransformationPreview.swift */,
 				516617A12AFA58CA00978554 /* TransitionPreview.swift */,
+				E931DA322B16A356005E940A /* BlurPreview.swift */,
+				E931DA342B16A68A005E940A /* ProgressiveBlurPreview.swift */,
+				E931DA362B16A6FE005E940A /* ShapeBlurPreview.swift */,
 			);
 			path = ShaderPreviews;
 			sourceTree = "<group>";
@@ -176,6 +194,7 @@
 		51C72B6C2AFBE7C40094D932 /* Shaders */ = {
 			isa = PBXGroup;
 			children = (
+				E931DA282B1686D5005E940A /* Blur */,
 				51C72B872AFBE7C40094D932 /* Generation */,
 				51C72B772AFBE7C40094D932 /* Transformation */,
 				51C72B6D2AFBE7C40094D932 /* Transition */,
@@ -254,6 +273,7 @@
 			isa = PBXGroup;
 			children = (
 				51C72B6C2AFBE7C40094D932 /* Shaders */,
+				E931DA2B2B169C55005E940A /* SwiftUI Wrappers */,
 				5188339E2AFBD66200D30D44 /* Helpers */,
 				5188339D2AFBD5ED00D30D44 /* ShaderPreviews */,
 				5188339C2AFBD5D000D30D44 /* ShaderDescriptions */,
@@ -274,6 +294,23 @@
 				51DB1BA92AF3EFEF00518737 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		E931DA282B1686D5005E940A /* Blur */ = {
+			isa = PBXGroup;
+			children = (
+				E931DA292B1686F8005E940A /* VariableGaussianBlur.metal */,
+			);
+			path = Blur;
+			sourceTree = "<group>";
+		};
+		E931DA2B2B169C55005E940A /* SwiftUI Wrappers */ = {
+			isa = PBXGroup;
+			children = (
+				E931DA2C2B169C7E005E940A /* VisualEffect+variableBlur.swift */,
+				E931DA2E2B169CC4005E940A /* View+variableBlur.swift */,
+			);
+			path = "SwiftUI Wrappers";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -361,10 +398,13 @@
 				51C72B962AFBE7C40094D932 /* Emboss.metal in Sources */,
 				51C72B8B2AFBE7C40094D932 /* Pixellate.metal in Sources */,
 				51A63CEE2B05018A00A67C06 /* ToggleAlphaButton.swift in Sources */,
+				E931DA352B16A68A005E940A /* ProgressiveBlurPreview.swift in Sources */,
+				E931DA2D2B169C7E005E940A /* VisualEffect+variableBlur.swift in Sources */,
 				51C72B952AFBE7C40094D932 /* GradientFill.metal in Sources */,
 				51DB1BA52AF3EFEE00518737 /* ContentView.swift in Sources */,
 				51C72B672AFBE7800094D932 /* Transitions.swift in Sources */,
 				51C72B9F2AFBE7C40094D932 /* Infrared.metal in Sources */,
+				E931DA2F2B169CC4005E940A /* View+variableBlur.swift in Sources */,
 				51C72B8A2AFBE7C40094D932 /* CircleWave.metal in Sources */,
 				51C72B8D2AFBE7C40094D932 /* Radial.metal in Sources */,
 				516617A82AFA6BC300978554 /* String-ShaderName.swift in Sources */,
@@ -376,6 +416,7 @@
 				51A63DC02B0570F400A67C06 /* Interlace.metal in Sources */,
 				51C72BA02AFBE7C40094D932 /* ColorPlanes.metal in Sources */,
 				51C72B9B2AFBE7C40094D932 /* SimpleLoupe.metal in Sources */,
+				E931DA332B16A356005E940A /* BlurPreview.swift in Sources */,
 				51C72B982AFBE7C40094D932 /* WhiteNoise.metal in Sources */,
 				51C72B892AFBE7C40094D932 /* Diamond.metal in Sources */,
 				51C72B942AFBE7C40094D932 /* AnimatedGradientFill.metal in Sources */,
@@ -394,10 +435,13 @@
 				518833952AFBC0DF00D30D44 /* ContentPreviewSelector.swift in Sources */,
 				516617B22AFA717500978554 /* RelativeTouchTransformationPreview.swift in Sources */,
 				5166179C2AFA543700978554 /* TransitionShader.swift in Sources */,
+				E931DA2A2B1686F8005E940A /* VariableGaussianBlur.metal in Sources */,
 				51C72B902AFBE7C40094D932 /* Wind.metal in Sources */,
 				516617962AFA4B2300978554 /* SimpleTransformationPreview.swift in Sources */,
+				E931DA372B16A6FE005E940A /* ShapeBlurPreview.swift in Sources */,
 				51C72BA92AFD36A80094D932 /* LightGrid.metal in Sources */,
 				516617B02AFA711B00978554 /* AbsoluteTouchTransformationPreview.swift in Sources */,
+				E931DA312B169DD2005E940A /* BlurEffect.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sandbox/Inferno/ContentView.swift
+++ b/Sandbox/Inferno/ContentView.swift
@@ -59,6 +59,14 @@ struct ContentView: View {
                         }
                     }
                 }
+                
+                Section("Blurs") {
+                    ForEach(BlurEffect.effects) { effect in
+                        NavigationLink(value: effect) {
+                            Text(effect.name)
+                        }
+                    }
+                }
             }
             .navigationTitle("Inferno Sandbox")
             .navigationDestination(for: SimpleTransformationShader.self) { shader in
@@ -82,6 +90,7 @@ struct ContentView: View {
                 TransitionPreview(shader: shader).id(UUID())
             }
             .navigationDestination(for: GenerativeShader.self, destination: GenerativePreview.init)
+            .navigationDestination(for: BlurEffect.self, destination: BlurPreview.init)
             .frame(minWidth: 200)
         } detail: {
             WelcomeView()

--- a/Sandbox/Inferno/ShaderDescriptions/BlurEffect.swift
+++ b/Sandbox/Inferno/ShaderDescriptions/BlurEffect.swift
@@ -1,0 +1,47 @@
+//
+//  BlurShader.swift
+//  Inferno
+//
+//  Created by Dale Price on 11/28/23.
+//
+
+import SwiftUI
+
+/// An effect based on a blur shader that specifies the effect to use.
+struct BlurEffect: Hashable, Identifiable {
+    
+    /// Specifies the type of blur effect to apply. These all use the same shader but draw a different mask using SwiftUI's `GraphicsContext`.
+    enum EffectType {
+        /// A blur masked with a linear gradient.
+        case progressiveBlur
+        
+        /// A blur masked with a shape.
+        case shape(any Shape)
+    }
+    
+    // Unique, random identifier for this effect.
+    var id = UUID()
+    
+    /// The human readable name for this effect.
+    var name: String
+    
+    /// The type of blur effect to use.
+    var effect: EffectType
+    
+    /// Custom Equatable conformance.
+    static func ==(lhs: BlurEffect, rhs: BlurEffect) -> Bool {
+        lhs.id == rhs.id
+    }
+    
+    /// Custom Hashable conformance.
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    
+    /// All the blur effects we want to show.
+    static let effects: [BlurEffect] = [
+        BlurEffect(name: "Progressive Blur", effect: .progressiveBlur),
+        BlurEffect(name: "Vignette", effect: .shape(Ellipse())),
+        BlurEffect(name: "Rounded Rectangle Mask", effect: .shape(RoundedRectangle(cornerRadius: 25.0)))
+    ]
+}

--- a/Sandbox/Inferno/ShaderPreviews/BlurPreview.swift
+++ b/Sandbox/Inferno/ShaderPreviews/BlurPreview.swift
@@ -1,0 +1,36 @@
+//
+//  BlurPreview.swift
+//  Inferno
+//
+//  Created by Dale Price on 11/28/23.
+//
+
+import SwiftUI
+
+/// A SwiftUI view that displays a specific blur effect preview.
+struct BlurPreview: View {
+    /// The opacity of the preview view.
+    @State private var opacity = 1.0
+    
+    /// The effect to render.
+    var effect: BlurEffect
+    
+    var body: some View {
+        Group {
+            switch effect.effect {
+            case .progressiveBlur:
+                ProgressiveBlurPreview(opacity: $opacity)
+            case .shape(let shape):
+                ShapeBlurPreview(opacity: $opacity, shape: shape)
+            }
+        }
+        .toolbar {
+            ToggleAlphaButton(opacity: $opacity)
+        }
+        .navigationSubtitle(effect.name)
+    }
+}
+
+#Preview {
+    BlurPreview(effect: BlurEffect.effects[0])
+}

--- a/Sandbox/Inferno/ShaderPreviews/ProgressiveBlurPreview.swift
+++ b/Sandbox/Inferno/ShaderPreviews/ProgressiveBlurPreview.swift
@@ -1,0 +1,70 @@
+//
+//  ProgressiveBlurPreview.swift
+//  Inferno
+//
+//  Created by Dale Price on 11/28/23.
+//
+
+import SwiftUI
+
+/// A SwiftUI view that renders a gradient blur using the VariableGaussianBlur Metal shader.
+struct ProgressiveBlurPreview: View {
+    /// A binding to the opacity set in the parent view.
+    @Binding var opacity: Double
+    
+    /// The start position of the variable blur, from 0 (top) to 1 (bottom).
+    @State private var start = 0.0
+    
+    /// The start position of the variable blur, from 0 (top) to 1 (bottom).
+    @State private var end = 1.0
+    
+    /// The blur radius.
+    @State private var radius = 10.0
+    
+    /// The maximum number of samples to use for the blur.
+    @State private var maxSamples = 15.0
+    
+    var body: some View {
+        VStack {
+            ContentPreviewSelector()
+            
+            ContentPreview()
+                .variableBlur(radius: radius, maxSampleCount: Int(maxSamples)) { geometryProxy, context in
+                    // Draw a rectangle covering the entire mask and fill it using a linear gradient from the specified points within the view's frame.
+                    context.fill(
+                        Path(geometryProxy.frame(in: .local)),
+                        with: .linearGradient(
+                            .init(colors: [.white, .clear]),
+                            startPoint: .init(x: 0, y: geometryProxy.size.height * start),
+                            endPoint: .init(x: 0, y: geometryProxy.size.height * end)
+                        )
+                    )
+                }
+            // We need to give the view an ID based on the parameters used within the drawing callback so that SwiftUI will call it again when they change.
+                .id(start)
+                .id(end)
+                .opacity(opacity)
+            
+            GroupBox {
+                LabeledContent("Blur Radius") {
+                    Slider(value: $radius, in: 0.0...100.0)
+                }
+                LabeledContent("Blur Mask Start") {
+                    Slider(value: $start, in: 0.0...1.0)
+                }
+                LabeledContent("Blur Mask End") {
+                    Slider(value: $end, in: 0.0...1.0)
+                }
+                LabeledContent("Maximum Sample Count") {
+                    Slider(value: $maxSamples, in: 1.0...30.0, step: 1.0)
+                }
+            }
+            .scenePadding()
+            .frame(maxWidth: 500)
+        }
+    }
+}
+
+#Preview {
+    ProgressiveBlurPreview(opacity: .constant(1))
+}

--- a/Sandbox/Inferno/ShaderPreviews/ShapeBlurPreview.swift
+++ b/Sandbox/Inferno/ShaderPreviews/ShapeBlurPreview.swift
@@ -1,0 +1,91 @@
+//
+//  ShapeBlurPreview.swift
+//  Inferno
+//
+//  Created by Dale Price on 11/28/23.
+//
+
+import SwiftUI
+
+/// A SwiftUI view that renders a variable blur masked by a shape, using the VariableGaussianBlur Metal shader.
+struct ShapeBlurPreview: View {
+    /// A binding to the opacity set in the parent view.
+    @Binding var opacity: Double
+    
+    /// The shape to use as a mask for the variable blur shader.
+    var shape: any Shape
+    
+    /// The amount to inset the shape relative to the view's frame, from 0 (no inset) to 0.5 (the center of the view)
+    @State private var shapeInset = 0.25
+    
+    /// The amount to fade the edges of the shape in the mask, defining how the variable blur effect fades in at the edges.
+    @State private var shapeFade = 5.0
+    
+    /// The blur radius.
+    @State private var radius = 20.0
+    
+    /// The maximum number of samples to use for the blur.
+    @State private var maxSamples = 15.0
+    
+    /// Whether to invert the mask (blur within the shape or outside the shape).
+    @State private var invertMask = true
+    
+    var body: some View {
+        VStack {
+            ContentPreviewSelector()
+            
+            ContentPreview()
+                .variableBlur(radius: radius, maxSampleCount: Int(maxSamples)) { geometryProxy, context in
+                    // Add a blur to the mask to fade the edges of the shape.
+                    context.addFilter(
+                        .blur(radius: shapeFade)
+                    )
+                    
+                    // Mask off the shape centered on the view, inset by `shapeInset` relative to the view's frame according to the proxy.
+                    let horizInset = geometryProxy.size.width * shapeInset
+                    let vertInset = geometryProxy.size.height * shapeInset
+                    context.clip(
+                        to: shape.path(in: CGRect(
+                            x: horizInset,
+                            y: vertInset,
+                            width: geometryProxy.size.width - horizInset * 2,
+                            height: geometryProxy.size.height - horizInset * 2)
+                        ), options: invertMask ? .inverse : []
+                    )
+                    
+                    // Fill the area of the mask that isn't clipped.
+                    context.fill(
+                        Path(geometryProxy.frame(in: .local)),
+                        with: .color(.white)
+                    )
+                }
+                .opacity(opacity)
+            // We need to give the view an ID based on the parameters used within the drawing callback so that SwiftUI will call it again when they change.
+                .id(shapeInset)
+                .id(shapeFade)
+                .id(invertMask)
+            
+            GroupBox {
+                LabeledContent("Blur Radius") {
+                    Slider(value: $radius, in: 0.0...100.0)
+                }
+                LabeledContent("Mask Shape Inset") {
+                    Slider(value: $shapeInset, in: 0.0...0.5)
+                }
+                LabeledContent("Mask Shape Blur") {
+                    Slider(value: $shapeFade, in: 0.0...100.0)
+                }
+                Toggle("Invert Mask", isOn: $invertMask)
+                LabeledContent("Maximum Sample Count") {
+                    Slider(value: $maxSamples, in: 1.0...30.0, step: 1.0)
+                }
+            }
+            .scenePadding()
+            .frame(maxWidth: 500)
+        }
+    }
+}
+
+#Preview {
+    ShapeBlurPreview(opacity: .constant(1), shape: Circle())
+}

--- a/Sandbox/Inferno/SwiftUI Wrappers/View+variableBlur.swift
+++ b/Sandbox/Inferno/SwiftUI Wrappers/View+variableBlur.swift
@@ -1,0 +1,70 @@
+//
+//  View+variableBlur.swift
+//  Inferno
+//
+//  Created by Dale Price on 11/28/23.
+//
+
+import SwiftUI
+
+@available(iOS 17, macOS 14, macCatalyst 17, tvOS 17, visionOS 1, *)
+public extension View {
+	
+	/// Applies a variable blur to the view, with the blur radius at each pixel determined by a mask image.
+	///
+	/// - Parameters:
+	///   - radius: The radial size of the blur in areas where the mask is fully opaque.
+	///   - maxSampleCount: The maximum number of samples the shader may take from the view's layer in each direction. Higher numbers produce a smoother, higher quality blur but are more GPU intensive. Values larger than `radius` have no effect. The default of 15 provides balanced results but may cause banding on some images at larger blur radii.
+	///   - verticalPassFirst: Whether or not to perform the vertical blur pass before the horizontal one. Changing this parameter may reduce smearing artifacts. Defaults to `false`, i.e. perform the horizontal pass first.
+	///   - mask: An `Image` to use as the mask for the blur strength.
+	/// - Returns: The view with the variable blur effect applied.
+	func variableBlur(
+		radius: CGFloat,
+		maxSampleCount: Int = 15,
+		verticalPassFirst: Bool = false,
+		mask: Image
+	) -> some View {
+		self.visualEffect { content, _ in
+			content.variableBlur(
+				radius: radius,
+				maxSampleCount: maxSampleCount,
+				verticalPassFirst: verticalPassFirst,
+				mask: mask
+			)
+		}
+	}
+	
+	/// Applies a variable blur to the view, with the blur radius at each pixel determined by a mask that you create.
+	///
+	/// - Parameters:
+	///   - radius: The radial size of the blur in areas where the mask is fully opaque.
+	///   - maxSampleCount: The maximum number of samples the shader may take from the view's layer in each direction. Higher numbers produce a smoother, higher quality blur but are more GPU intensive. Values larger than `radius` have no effect. The default of 15 provides balanced results but may cause banding on some images at larger blur radii.
+	///   - verticalPassFirst: Whether or not to perform the vertical blur pass before the horizontal one. Changing this parameter may reduce smearing artifacts. Defaults to `false`, i.e. perform the horizontal pass first.
+	///   - maskRenderer: A rendering closure to draw the mask used to determine the intensity of the blur at each pixel. The closure receives a `GeometryProxy` with the view's layout information, and a `GraphicsContext` to draw into.
+	/// - Returns: The view with the variable blur effect applied.
+	///
+	/// The strength of the blur effect at any point on the view is determined by the transparency of the mask at that point. Areas where the mask is fully opaque are blurred by the full radius; areas where the mask is partially transparent are blurred by a proportionally smaller radius. Areas where the mask is fully transparent are left unblurred.
+	///
+	/// - Tip: To achieve a progressive blur or gradient blur, draw a gradient from transparent to opaque in your mask image where you want the transition from clear to blurred to take place.
+	///
+	/// - Note: Because the blur is split into horizontal and vertical passes for performance, certain mask images over certain patterns may cause "smearing" artifacts along one axis. Changing the `verticalPassFirst` parameter may reduce this, but may cause smearing in the other direction.. To avoid smearing entirely, avoid drawing hard edges in your `maskRenderer`.
+	///
+	/// - Important: Because this effect is implemented as a SwiftUI `layerEffect`, it is subject to the same limitations. Namely, views backed by AppKit or UIKit views may not render. Instead, they log a warning and display a placeholder image to highlight the error.
+	func variableBlur(
+		radius: CGFloat,
+		maxSampleCount: Int = 15,
+		verticalPassFirst: Bool = false,
+		maskRenderer: @escaping (GeometryProxy, inout GraphicsContext) -> Void
+	) -> some View {
+		self.visualEffect { content, geometryProxy in
+			content.variableBlur(
+				radius: radius,
+				maxSampleCount: maxSampleCount,
+				verticalPassFirst: verticalPassFirst,
+				mask: Image(size: geometryProxy.size, renderer: { context in
+					maskRenderer(geometryProxy, &context)
+				})
+			)
+		}
+	}
+}

--- a/Sandbox/Inferno/SwiftUI Wrappers/VisualEffect+variableBlur.swift
+++ b/Sandbox/Inferno/SwiftUI Wrappers/VisualEffect+variableBlur.swift
@@ -1,0 +1,56 @@
+//
+//  VisualEffect+variableBlur.swift
+//  Inferno
+//
+//  Created by Dale Price on 11/28/23.
+//
+
+import SwiftUI
+
+@available(iOS 17, macOS 14, macCatalyst 17, tvOS 17, visionOS 1, *)
+public extension VisualEffect {
+    
+    /// Applies a variable blur, with the blur radius at each pixel determined by a mask image.
+    ///
+    /// - Tip: To automatically generate a mask image of the same size as the view, use ``SwiftUI/View/variableBlur(radius:maxSampleCount:verticalPassFirst:maskRenderer:)`` which creates the image from drawing instructions you provide to a `GraphicsContext`.
+    ///
+    /// - Parameters:
+    ///   - radius: The maximum radial size of the blur in areas where the mask is fully opaque.
+    ///   - maxSampleCount: The maximum number of samples to take from the view's layer in each direction. Higher numbers produce a smoother, higher quality blur but are more GPU intensive. Values larger than `radius` have no effect.
+    ///   - verticalPassFirst: Whether or not to perform the vertical blur pass before the horizontal one. Changing this parameter may reduce smearing artifacts. Defaults to `false`, i.e. perform the horizontal pass first.
+    ///   - mask: An image with an alpha channel to use as mask to determine the strength of the blur effect at each pixel. Fully transparent areas are unblurred; fully opaque areas are blurred by the full radius; partially transparent areas are blurred by the radius multiplied by the alpha value. The mask will be uv-mapped to cover the entire view.
+    ///   - isEnabled: Whether the effect is enabled or not.
+    /// - Returns: A new view that renders `self` with the blur shader applied as a layer effect.
+    ///
+    /// - Important: Because this effect is based on SwiftUI's `layerEffect`, views backed by AppKit or UIKit views may not render. Instead, they log a warning and display a placeholder image to highlight the error.
+    func variableBlur(
+        radius: CGFloat,
+        maxSampleCount: Int = 15,
+        verticalPassFirst: Bool = false,
+        mask: Image,
+        isEnabled: Bool = true
+    ) -> some VisualEffect {
+        self.layerEffect(
+            ShaderLibrary.variableBlur(
+                .boundingRect,
+                .float(radius),
+                .float(CGFloat(maxSampleCount)),
+                .image(mask),
+                .float(verticalPassFirst ? 1 : 0)
+            ),
+            maxSampleOffset: CGSize(width: radius , height: radius),
+            isEnabled: isEnabled
+        )
+        .layerEffect(
+            ShaderLibrary.variableBlur(
+                .boundingRect,
+                .float(radius),
+                .float(CGFloat(maxSampleCount)),
+                .image(mask),
+                .float(verticalPassFirst ? 0 : 1)
+            ),
+            maxSampleOffset: CGSize(width: radius, height: radius),
+            isEnabled: isEnabled
+        )
+    }
+}

--- a/Shaders/Blur/VariableGaussianBlur.metal
+++ b/Shaders/Blur/VariableGaussianBlur.metal
@@ -1,0 +1,101 @@
+//
+//  VariableGaussianBlur.metal
+//  Inferno
+//
+//  Created by Dale Price on 11/28/23.
+//
+
+#include <metal_stdlib>
+#include <SwiftUI/SwiftUI_Metal.h>
+using namespace metal;
+
+
+/// Formula of a gaussian function for a single axis as described by https://en.wikipedia.org/wiki/Gaussian_blur. Creates a "bell curve" shape which we'll use for the weight of each sample when averaging.
+///
+/// - Parameter distance: The distance from the origin along the current axis.
+/// - Parameter sigma: The desired standard deviation of the bell curve.
+inline half gaussian(half distance, half sigma) {
+    // Calculate the exponent of the Gaussian equation.
+    const half gaussianExponent = -(distance * distance) / (2.0h * sigma * sigma);
+    
+    // Calculate and return the entire Gaussian equation.
+    return (1.0h / (2.0h * M_PI_H * sigma * sigma)) * exp(gaussianExponent);
+}
+
+/// Calculate pixel color using the weighted average of multiple samples along the X axis.
+///
+/// - Parameter position: The coordinates of the current pixel.
+/// - Parameter layer: The SwiftUI layer we're reading from.
+/// - Parameter radius: The desired blur radius.
+/// - Parameter axisMultiplier: A vector defining which axis to sample along. Should be (1, 0) for X, or (0, 1) for Y.
+/// - Parameter maxSamples: The maximum number of samples to read in each direction from the current pixel. Texture sampling is expensive, so instead of sampling every pixel, we use a lower count spread out across the radius.
+half4 gaussianBlur1D(float2 position, SwiftUI::Layer layer, half radius, half2 axisMultiplier, half maxSamples) {
+    // Calculate how far apart the samples should be: either 1 pixel or the desired radius divided by the maximum number of samples, whichever is farther.
+    const half interval = max(1.0h, radius / maxSamples);
+    
+    // Take the first sample.
+    // Calculate the weight for this sample in the weighted average using the Gaussian equation.
+    const half weight = gaussian(0.0h, radius / 2.0h);
+    // Sample the pixel at the current position and multiply its color by the weight, to use in the weighted average.
+    // Each sample's color will be combined into the `weightedColorSum` variable (the numerator for the weighted average).
+    half4 weightedColorSum = layer.sample(position) * weight;
+    // The `totalWeight` variable will keep track of the sum of all weights (the denominator for the weighted average). Start with the weight of the current sample.
+    half totalWeight = weight;
+    
+    // If the radius is high enough to take more samples, take them.
+    if(interval <= radius) {
+        
+        // Take a sample every `interval` up to and including the desired blur radius.
+        for (half distance = interval; distance <= radius; distance += interval) {
+            // Calculate the sample offset as a 2D vector.
+            const half2 offsetDistance = axisMultiplier * distance;
+            
+            // Calculate the sample's weight using the Gaussian equation. For the sigma value, we use half the blur radius so that the resulting bell curve fits nicely within the radius.
+            const half weight = gaussian(distance, radius / 2.0h);
+            
+            // Add the weight to the total. Double the weight because we are taking two samples per iteration.
+            totalWeight += weight * 2.0h;
+            
+            // Take two samples along the axis, one in the positive direction and one negative, multiply by weight, and add to the sum.
+            weightedColorSum += layer.sample(float2(half2(position) + offsetDistance)) * weight;
+            weightedColorSum += layer.sample(float2(half2(position) - offsetDistance)) * weight;
+        }
+    }
+    
+    // Return the weighted average color of the samples by dividing the weighted sum of the colors by the sum of the weights.
+    return weightedColorSum / totalWeight;
+}
+
+/// Variable blur effect along the specified axis that samples from a texture to determine the blur radius multiplier at each pixel. This shader requires two passes, one along the X axis and one along the Y.
+///
+/// The two-pass approach is better for performance as it scales linearly rather than exponentially with pixel count * radius * sample count, but can result in "streak" artifacts where blurred areas meet unblurred areas.
+///
+/// - Parameter position: The coordinates of the current pixel in user space.
+/// - Parameter layer: The SwiftUI layer we're applying the blur to.
+/// - Parameter boundingRect: The bounding rectangle of the SwiftUI view in user space.
+/// - Parameter radius: The desired maximum blur radius for areas of the mask that are fully opaque.
+/// - Parameter maxSamples: The maximum number of samples to read _in each direction_ from the current pixel. Reducing this value increases performance but results in banding in the resulting blur.
+/// - Parameter mask: The texture to sample alpha values from to determine the blur radius at each pixel.
+/// - Parameter vertical: Specifies to blur along the Y axis. Because SwiftUI can't pass booleans to a shader, `0.0` is treated as false (i.e. blur the X axis)  and any other value is treated as true (i.e. blur the Y axis).
+[[ stitchable ]] half4 variableBlur(float2 pos, SwiftUI::Layer layer, float4 boundingRect, float radius, float maxSamples, texture2d<half> mask, float vertical) {
+    // Calculate the position in UV space within the bounding rect (0 to 1).
+    const float2 uv = float2(pos.x / boundingRect[2], pos.y / boundingRect[3]);
+    
+    // Sample the alpha value of the mask at the current UV position.
+    const half maskAlpha = mask.sample(metal::sampler(metal::filter::linear), uv).a;
+    
+    // Determine the blur radius at this pixel by multiplying the alpha value from the mask with the radius parameter.
+    const half pixelRadius = maskAlpha * half(radius);
+    
+    // If the resulting radius is 1 pixel or greater…
+    if(pixelRadius >= 1) {
+        // Set the "axis multiplier" value that tells the blur function whether to sample along the X or Y axis.
+        const half2 axisMultiplier = vertical == 0.0 ? half2(1, 0) : half2(0, 1);
+        
+        // Return the blurred color.
+        return gaussianBlur1D(pos, layer, pixelRadius, axisMultiplier, maxSamples);
+    } else {
+        // If the blur radius is less than 1 pixel, return the current pixel's color as-is.
+        return layer.sample(pos);
+    }
+}


### PR DESCRIPTION
This adds the variable Gaussian blur shader and SwiftUI wrappers from [Variablur](https://github.com/daprice/Variablur). Like you suggested on Mastodon, I added a sidebar category containing:

#### Progressive Blur
Uses a vertical gradient as the mask for the variable blur, lets people change the start and end points for the gradient
<img width="1112" alt="Screenshot 2023-11-28 at 6 00 56 PM" src="https://github.com/twostraws/Inferno/assets/3615519/98fb416c-f479-4db6-a045-17251a6fa514">

#### Vignette
Uses an ellipse as the mask, lets people change the inset amount as well as blur the mask itself to fade the edges of the blur
<img width="1112" alt="Screenshot 2023-11-28 at 6 01 17 PM" src="https://github.com/twostraws/Inferno/assets/3615519/429225f6-8dc3-4e73-9c9f-74f28b31f1b5">

#### Rounded Rectangle Mask
Demonstrates how you can draw any shape into the mask, same UI as vignette. Both shapes (vignette and rounded rect) can be inverted to blur different parts of the view.
<img width="1112" alt="Screenshot 2023-11-28 at 6 01 53 PM" src="https://github.com/twostraws/Inferno/assets/3615519/fc46b7da-2a8b-48ed-a0e0-6f163bc00e31">
<img width="1112" alt="Screenshot 2023-11-28 at 6 02 05 PM" src="https://github.com/twostraws/Inferno/assets/3615519/9ebda33e-5f96-45cd-9e68-c5a656a88f5e">
