### PR TITLE
Added newline for emboss image

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ struct ContentView: View {
 
 <details>
 <summary> Details (Click to expand) </summary>
+
 ![An emboss shader.](assets/emboss.png)
 
 A `layerEffect()` shader that creates an embossing effect by adding brightness from pixels in one direction, and subtracting brightness from pixels in the other direction.


### PR DESCRIPTION
Hey Paul!

I was checking out the available shaders in the README and noticed that emboss.png wasn't rendering. I think a newline is needed in the markup.

Before:
![Screenshot 2023-12-10 at 10 51 33 AM](https://github.com/twostraws/Inferno/assets/15333030/55ed0414-11f2-4550-8046-17c0c076f6f9)


After:
![Screenshot 2023-12-10 at 10 51 51 AM](https://github.com/twostraws/Inferno/assets/15333030/e2387b06-8248-4175-bbd6-11dc5ab1b1dd)
