### PR TITLE
Add more discoverable methods to use shaders

### DIFF
--- a/Sources/Inferno/SwiftUI/Shader/Shader.Inferno.Color.swift
+++ b/Sources/Inferno/SwiftUI/Shader/Shader.Inferno.Color.swift
@@ -1,0 +1,16 @@
+//
+// Shader.Inferno.swift
+// Inferno
+// https://www.github.com/twostraws/Inferno
+// See LICENSE for license information.
+//
+
+import SwiftUI
+
+@available(iOS 17, macOS 14, macCatalyst 17, tvOS 17, visionOS 1, *)
+public extension Shader.inferno {
+	
+	/// A namespace for all `colorEffect` shaders exported by Inferno
+	enum color {}
+}
+

--- a/Sources/Inferno/SwiftUI/Shader/Shader.Inferno.Color.swift
+++ b/Sources/Inferno/SwiftUI/Shader/Shader.Inferno.Color.swift
@@ -14,3 +14,21 @@ public extension Shader.inferno {
 	enum color {}
 }
 
+@available(iOS 17, macOS 14, macCatalyst 17, tvOS 17, visionOS 1, *)
+public extension Shader.inferno.color {
+	/// A shader that generates a constantly cycling color gradient, centered
+	/// on the input view.
+	///
+	/// - Parameters:
+	///   - size: The size of the whole image, in user-space.
+	///   - elapsedTime: The number of elapsed seconds since the shader was created
+	static func animatedGradientFill(
+		size: CGSize,
+		elapsedTime: Double
+	) -> Shader {
+		InfernoShaderLibrary.animatedGradientFill(
+			.float2(size),
+			.float(elapsedTime)
+		)
+	}
+}

--- a/Sources/Inferno/SwiftUI/Shader/Shader.Inferno.swift
+++ b/Sources/Inferno/SwiftUI/Shader/Shader.Inferno.swift
@@ -1,0 +1,15 @@
+//
+// Shader.Inferno.swift
+// Inferno
+// https://www.github.com/twostraws/Inferno
+// See LICENSE for license information.
+//
+
+import SwiftUI
+
+@available(iOS 17, macOS 14, macCatalyst 17, tvOS 17, visionOS 1, *)
+public extension Shader {
+	
+	/// A namespace for all shaders exported by Inferno
+	enum inferno {}
+}


### PR DESCRIPTION
This PR addresses #15 

This current syntax for using an Inferno shader in a SwiftUI view is as below:

```swift
Image(systemName: "figure.walk.circle")
    .font(.system(size: 300))
    .visualEffect { content, proxy in
        content
            .colorEffect(
                InfernoShaderLibrary.animatedGradientFill(
                    .float2(proxy.size),
                    .float(elapsedTime)
            )
        )
    }
```

This has some issues such as:
- Poor discoverability, as Xcode autocomplete isn't great at filling in shader names
- Missing diagnostics for referring to the incorrect ShaderLibrary, as you'd need to specify `InfernoShaderLibrary` and not `ShaderLibrary` when importing Inferno in another module
- No right click documentation for any of the shaders
- No guidance as to which shader goes with which modifier (To use a shader with the `colorEffect` modifier, it needs to have a specific signature, for example)
- No autocomplete for parameter names, types, and ordering
- Requiring you to use Shader-specific argument types like `Shader.Argument.float`
- No real way to communicate migration warnings if you were to rename a shader, add more parameters, etc.

This PR introduces some new convenience APIs that help remedy these issues.

Firstly, there's a new top level `Shader.inferno` top level namespace which contains all the new Swift code, to minimise the API surface. `Shader.inferno` itself contains 3 namespaces, `color`, `distortion`, and `layer`. Each of these namespaces contains static functions to generate each shader, taking native Swift types as parameters, where required. I've currently only added a method for `animatedGradientFill` as a test case.

This allows us to get full autocomplete and documentation support in Xcode. Typing `.` in any parameter field that expects a shader brings up `.inferno` as an autocomplete suggestion, and then the sub-namespaces and individual method names beyond that, along with familiar Swift types for the parameters such as `CGSize` and `Double`, instead of `Shader.Argument`. 

With this PR, the above code can be rewritten as:

```swift
Image(systemName: "figure.walk.circle")
    .font(.system(size: 300))
    .visualEffect { content, proxy in
        content
            .colorEffect(
                .inferno.color.animatedGradientFill(
                    size: proxy.size,
                    elapsedTime: time
                )
            )
    }
```

I've gone with this approach because since the library only provides shaders, it made most sense to just make it easier to generate `SwiftUI.Shader` types, rather than providing any custom view modifiers, and is also extensible for more shader formats or view modifiers from Apple in the future.

This means you can use this syntax in every place where SwiftUI allows you to use a `Shader` without having to learn any special syntax that might differ from both other libraries and shaders you define in your app, while also letting SwiftUI handle other parameters for those modifiers like `isEnabled` for all 3 effects, and `maxSampleOffset` for distortion and layer effects.

This PR only includes an API for the `animatedGradientFill` shader just to explore the concept and structure, I'd be happy to bring over the rest if this seems like the correct direction.