### PR TITLE
Tip markup housekeeping in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ SwiftUI provides three modifiers that let us apply Metal shaders to view hierarc
 
 In the documentation below, shader parameters are listed _without_ the ones SwiftUI passes in automatically – you just see the ones you actually need to pass yourself.
 
-> [!Tip]
+> **Tip:**
 > When writing more complex shaders, you'll often find yourself needing to optimize your code for maximum efficiency. One of the best places to start with this is by looking into *shader uniforms*: rather than calculating a value that is the same for every fragment inside a shader, instead precompute values on the CPU and pass them directly into the shader. This means such calculations are done once per draw, rather than once per fragment.
 
 </details>
@@ -972,7 +972,7 @@ struct ContentView: View {
 
 As well as the shaders listed above, Inferno provides a selection of shaders specifically designed to be used as transitions. Although these are still Metal shaders internally, you'll use them through `AnyTransition` extensions that make the process seamless.
 
-> [!Tip]
+> **Tip:**
 > As well as copying one specific shader into your project, you should also add Transitions.swift to include the `AnyTransition` extensions.
 
 ### Circle
@@ -1522,7 +1522,7 @@ If you’ve modified one of the shaders and want to see how it looks, the sandbo
 
 All shaders here work great on all devices that support macOS Sonoma and coordinated releases, including iOS 17.
 
-> [!Tip]
+> **Tip:**
 > Although the sandbox is helpful for previewing shaders, almost all its code isn't required in order to use Inferno shaders in your own projects – you just need to copy the relevant Metal files across, and optionally also Transitions.swift if you're using a transition shader.
 
 ## Contributing


### PR DESCRIPTION
I think I spotted a typo with the tip markup syntax.

Before:
<img width="802" alt="Screenshot 2024-01-14 at 8 33 36 PM" src="https://github.com/twostraws/Inferno/assets/15333030/4b501995-db79-4a0f-9709-7bc935fde814">

After:
<img width="827" alt="Screenshot 2024-01-14 at 8 33 57 PM" src="https://github.com/twostraws/Inferno/assets/15333030/4ea90575-ac16-4516-be4c-9788111dab8f">
