### PR TITLE
Improved readability of comments. 

### DIFF
--- a/Sandbox/Inferno/Helpers/PreviewType.swift
+++ b/Sandbox/Inferno/Helpers/PreviewType.swift
@@ -9,15 +9,15 @@ import Foundation
 
 /// The various preview options we provide.
 enum PreviewType: String {
-    // A flag emoji.
+    /// A flag emoji.
     case emoji
 
-    // An image from our asset catalog.
+    /// An image from our asset catalog.
     case image
 
-    // A solid rectangle.
+    /// A solid rectangle.
     case shape
 
-    // An interesting SF Symbol.
+    /// An interesting SF Symbol.
     case symbol
 }

--- a/Sandbox/Inferno/Helpers/TransformationType.swift
+++ b/Sandbox/Inferno/Helpers/TransformationType.swift
@@ -10,17 +10,17 @@ import Foundation
 
 /// Contains the various different effects we want to apply.
 enum TransformationType {
-    // Applies a colorEffect() modifier.
+    /// Applies a `colorEffect()` modifier.
     case colorEffect
 
-    // Applies a distortionEffect() modifier.
+    /// Applies a `distortionEffect()` modifier.
     case distortionEffect
 
-    // Applies a visualEffect() modifier, with
-    // a colorEffect() modifier nested inside.
+    /// Applies a `visualEffect()` modifier, with
+    /// a `colorEffect()` modifier nested inside.
     case visualEffectColor
 
-    // Applies a visualEffect() modifier, with
-    // a distortionEffect() modifier nested inside.
+    /// Applies a `visualEffect()` modifier, with
+    /// a `distortionEffect()` modifier nested inside.
     case visualEffectDistortion
 }

--- a/Sandbox/Inferno/ShaderPreviews/ProgressiveBlurPreview.swift
+++ b/Sandbox/Inferno/ShaderPreviews/ProgressiveBlurPreview.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// A SwiftUI view that renders a gradient blur using the `VariableGaussianBlur Metal shader.
+/// A SwiftUI view that renders a gradient blur using the `VariableGaussianBlur` Metal shader.
 struct ProgressiveBlurPreview: View {
     /// A binding to the opacity set in the parent view.
     @Binding var opacity: Double

--- a/Sandbox/Inferno/ShaderPreviews/ProgressiveBlurPreview.swift
+++ b/Sandbox/Inferno/ShaderPreviews/ProgressiveBlurPreview.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// A SwiftUI view that renders a gradient blur using the VariableGaussianBlur Metal shader.
+/// A SwiftUI view that renders a gradient blur using the `VariableGaussianBlur Metal shader.
 struct ProgressiveBlurPreview: View {
     /// A binding to the opacity set in the parent view.
     @Binding var opacity: Double

--- a/Sandbox/Inferno/ShaderPreviews/ShapeBlurPreview.swift
+++ b/Sandbox/Inferno/ShaderPreviews/ShapeBlurPreview.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// A SwiftUI view that renders a variable blur masked by a shape, using the VariableGaussianBlur Metal shader.
+/// A SwiftUI view that renders a variable blur masked by a shape, using the `VariableGaussianBlur Metal shader.
 struct ShapeBlurPreview: View {
     /// A binding to the opacity set in the parent view.
     @Binding var opacity: Double
@@ -60,7 +60,7 @@ struct ShapeBlurPreview: View {
                     )
                 }
                 .opacity(opacity)
-            // We need to give the view an ID based on the parameters used within the drawing callback so that SwiftUI will call it again when they change.
+                // We need to give the view an ID based on the parameters used within the drawing callback so that SwiftUI will call it again when they change.
                 .id(shapeInset)
                 .id(shapeFade)
                 .id(invertMask)

--- a/Sandbox/Inferno/ShaderPreviews/ShapeBlurPreview.swift
+++ b/Sandbox/Inferno/ShaderPreviews/ShapeBlurPreview.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// A SwiftUI view that renders a variable blur masked by a shape, using the `VariableGaussianBlur Metal shader.
+/// A SwiftUI view that renders a variable blur masked by a shape, using the `VariableGaussianBlur` Metal shader.
 struct ShapeBlurPreview: View {
     /// A binding to the opacity set in the parent view.
     @Binding var opacity: Double

--- a/Sandbox/Inferno/ShaderPreviews/TimeTransformationPreview.swift
+++ b/Sandbox/Inferno/ShaderPreviews/TimeTransformationPreview.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// Renders a shader that requires a TimelineView to animate itself.
+/// Renders a shader that requires a `TimelineView` to animate itself.
 struct TimeTransformationPreview: View {
     /// The initial time this view was created, so we can send
     /// elapsed time to the shader.

--- a/Sources/Inferno/InfernoShaderLibrary.swift
+++ b/Sources/Inferno/InfernoShaderLibrary.swift
@@ -17,7 +17,7 @@ public enum InfernoShaderLibrary {
     /// Typically this subscript is used implicitly via the dynamic
     /// member syntax, for example:
     ///
-    ///    let fn = InfernoShaderLibrary.myFunction
+    /// ```let fn = InfernoShaderLibrary.myFunction```
     ///
     /// which creates a reference to the MSL function called
     /// `myFunction()`.

--- a/Sources/Inferno/Shaders/Transition/Genie.metal
+++ b/Sources/Inferno/Shaders/Transition/Genie.metal
@@ -15,7 +15,7 @@ float2 remap(float2 uv, float2 inputLow, float2 inputHigh, float2 outputLow, flo
     return final;
 }
 
-[[ stitchable ]] float2 genieTranstion(float2 position, float2 size, float effectValue) {
+[[ stitchable ]] float2 genieTransition(float2 position, float2 size, float effectValue) {
     // Normalized pixel coordinates (from 0 to 1)
     float2 normalizedPosition = position / size;
     float positiveEffect = effectValue*sign(effectValue);

--- a/Sources/Inferno/SwiftUI/Transitions.swift
+++ b/Sources/Inferno/SwiftUI/Transitions.swift
@@ -107,7 +107,7 @@ struct DiamondWaveTransition: ViewModifier {
 
 /// A Metal-powered layer effect transition that needs to know the
 /// view's size. You probably don't want to use this directly, and
-/// should instead use one of the AnyTransition extensions.
+/// should instead use one of the `AnyTransition` extensions.
 @available(iOS 17, macOS 14, macCatalyst 17, tvOS 17, visionOS 1, *)
 struct InfernoTransition: ViewModifier {
     /// The name of the shader function we're rendering.
@@ -131,9 +131,9 @@ struct InfernoTransition: ViewModifier {
 
 /// A Metal-powered distortion effect transition that needs to know
 /// the view's size. You probably don't want to use this directly, and
-/// should instead use one of the AnyTranstion extensions.
+/// should instead use one of the `AnyTransition` extensions.
 @available(iOS 17, macOS 14, macCatalyst 17, tvOS 17, visionOS 1, *)
-struct InferoDistortionTranstion: ViewModifier {
+struct InfernoDistortionTransition: ViewModifier {
     /// The name of the shader function we're rendering.
     var name: String
 
@@ -155,7 +155,7 @@ struct InferoDistortionTranstion: ViewModifier {
 
 /// A transition that causes the incoming and outgoing views to become
 /// increasingly pixellated, then return to their normal state. While this
-/// happens the old view fades out and the new one fades in.
+/// happens, the old view fades out and the new one fades in.
 @available(iOS 17, macOS 14, macCatalyst 17, tvOS 17, visionOS 1, *)
 struct PixellateTransition: ViewModifier {
     /// How large the pixels should be.
@@ -235,7 +235,7 @@ struct WindTransition: ViewModifier {
 extension AnyTransition {
     /// A transition that makes a variety of circles simultaneously zoom up
     ///  across the screen.
-    /// - Parameters:
+    ///
     /// - Parameter size: The size of the circles.
     public static func circles(size: Double = 20) -> AnyTransition {
         .asymmetric(
@@ -249,7 +249,7 @@ extension AnyTransition {
 
     /// A transition that makes a variety of circles zoom up across the screen,
     /// based on their X/Y position.
-    /// - Parameters:
+    ///
     /// - Parameter size: The size of the circles.
     public static func circleWave(size: Double = 20) -> AnyTransition {
         .asymmetric(
@@ -276,7 +276,7 @@ extension AnyTransition {
 
     /// A transition that makes a variety of circles zoom up across the screen,
     /// based on their X/Y position.
-    /// - Parameters:
+    ///
     /// - Parameter size: The size of the diamonds.
     public static func diamondWave(size: Double = 20) -> AnyTransition {
         .asymmetric(
@@ -316,7 +316,7 @@ extension AnyTransition {
 
     /// A transition that causes the incoming and outgoing views to become
     /// increasingly pixellated, then return to their normal state. While this
-    /// happens the old view fades out and the new one fades in.
+    /// happens, the old view fades out and the new one fades in.
     /// - Parameters:
     ///   - squares: How many pixel squares to create.
     ///   - steps: How many animation steps to use; anything >= 60 looks smooth.
@@ -334,16 +334,16 @@ extension AnyTransition {
     }
 
     /// A transition that causes the incoming and outgoing views to become
-    /// sucked in and ouf of the top right corner.
+    /// sucked in and out of the top right corner.
     public static func genie() -> AnyTransition {
         .asymmetric(
             insertion: .modifier(
-                active: InferoDistortionTranstion(name: "genieTranstion", progress: 1),
-                identity:  InferoDistortionTranstion(name: "genieTranstion", progress: 0)
+                active: InfernoDistortionTransition(name: "genieTransition", progress: 1),
+                identity:  InfernoDistortionTransition(name: "genieTransition", progress: 0)
             ),
             removal: .modifier(
-                active:  InferoDistortionTranstion(name: "genieTranstion", progress: 1),
-                identity:  InferoDistortionTranstion(name: "genieTranstion", progress: 0)
+                active:  InfernoDistortionTransition(name: "genieTransition", progress: 1),
+                identity:  InfernoDistortionTransition(name: "genieTransition", progress: 0)
             )
         )
     }
@@ -360,7 +360,7 @@ extension AnyTransition {
     /// A transition that increasingly twists the contents of the incoming and outgoing
     /// views, then untwists them to complete the transition. As this happens the two
     /// views fade to move smoothly from one to the other.
-    /// - Parameters:
+    ///
     /// - Parameter radius: How much of the view to swirl, in the range 0 to 1. Start with 0.5 and experiment.
     public static func swirl(radius: Double = 0.5) -> AnyTransition {
         .asymmetric(
@@ -375,9 +375,9 @@ extension AnyTransition {
         )
     }
 
-    /// A transition that makes it look the pixels of one image are being blown
+    /// A transition that makes it look like the pixels of one image are being blown
     /// away horizontally.
-    /// - Parameters:
+    ///
     /// - Parameter size: How big the wind streaks should be, relative to the view's width.
     public static func wind(size: Double = 0.2) -> AnyTransition {
         .asymmetric(


### PR DESCRIPTION
I fixed a few typos in the comments. I also improved the readability of some comments.

In Sources/Inferno/Shaders/Transition/Genie.metal, there was a typo in the function name which I fixed.

In Sources/Inferno/SwiftUI/Transitions.swift, the InfernoDistortionTransition name had several typos which I fixed.

The function descriptions of the Metal shaders could, in my opinion, have a better readability. I changed the documentation of Sources/Inferno/Shaders/Blur/VariableGaussianBlur.metal to my proposed style.

If you find this documentation style to be an improvement over the current one, I'll be happy to modify all the other documentation as well.