### PR TITLE
Updated whitenoise shader

### DIFF
--- a/Sources/Inferno/Shaders/Transformation/WhiteNoise.metal
+++ b/Sources/Inferno/Shaders/Transformation/WhiteNoise.metal
@@ -10,49 +10,22 @@ using namespace metal;
 
 /// A simple function that attempts to generate a random number based on various
 /// fixed input parameters.
-/// - Parameter offset: A fixed value that controls pseudorandomness.
-/// - Parameter position: The position of the pixel we're working with.
-/// - Parameter time: The number of elapsed seconds since the shader was created.
-/// - Returns: The original pixel color.
-float whiteRandom(float offset, float2 position, float time) {
-    // Pick two numbers that are unlikely to repeat.
-    float2 nonRepeating = float2(12.9898 * time, 78.233 * time);
 
-    // Multiply our texture coordinates by the
-    // non-repeating numbers, then add them together.
-    float sum = dot(position, nonRepeating);
-
-    // Calculate the sine of our sum to get a range
-    // between -1 and 1.
-    float sine = sin(sum);
-
-    // Multiply the sine by a big, non-repeating number
-    // so that even a small change will result in a big
-    // color jump.
-    float hugeNumber = sine * 43758.5453 * offset;
-
-    // Send back just the numbers after the decimal point.
-    return fract(hugeNumber);
+half4 randomNoise(
+    float2 position, /// The position in 2D space for which we're generating noise
+    half4 color,     /// The base color that will be modified by the noise
+    float time       /// The current time, used to animate the noise
+) {
+    // Generate a pseudo-random value based on the position and time.
+    // `dot(position + time, float2(12.9898, 78.233))` computes a dot product which helps in producing a pseudo-random effect.
+    // `sin(...) * 43758.5453` creates further randomness.
+    // `fract(...)` ensures that the value stays within the range [0, 1] by returning the fractional part.
+    float value = fract(sin(dot(position + time, float2(12.9898, 78.233))) * 43758.5453);
+    
+    // Create a color based on the generated noise value.
+    // The resulting color is grayscale because all RGB components are set to the same value.
+    // The alpha channel is set to 1.
+    // The final result is multiplied by the alpha of the input color to maintain its transparency.
+    return half4(value, value, value, 1) * color.a;
 }
 
-/// A shader that generates dynamic, grayscale noise.
-///
-/// This works identically to the Rainbow Noise shader, except it uses grayscale
-/// rather than rainbow colors.
-///
-/// - Parameter position: The user-space coordinate of the current pixel.
-/// - Parameter color: The current color of the pixel.
-/// - Parameter time: The number of elapsed seconds since the shader was created
-/// - Returns: The new pixel color.
-[[ stitchable ]] half4 whiteNoise(float2 position, half4 color, float time) {
-    // If it's not transparent…
-    if (color.a > 0.0h) {
-        // Make a color where the RGB values are the same
-        // random number and A is 1; multiply by the
-        // original alpha to get smooth edges.
-        return half4(half3(whiteRandom(1.0, position, time)), 1.0h) * color.a;
-    } else {
-        // Use the current (transparent) color.
-        return color;
-    }
-}


### PR DESCRIPTION
The original version of the white-noise shader had an issue where, after some time (approximately 2 minutes), diagonal lines appeared on the shader. The updated shader uses essentially the same formula but is a bit simpler and does not have this issue. It has been tested on both simulators and real devices.
Original:
![IMG_0208](https://github.com/twostraws/Inferno/assets/114776102/7db368a2-5f5e-4556-8124-72d38865cfce)
Updated:
![IMG_4880](https://github.com/twostraws/Inferno/assets/114776102/70a0acd2-3f22-4eb4-bbb2-6116f888a7b8)

